### PR TITLE
Add forced result option

### DIFF
--- a/src/WorldFacade.js
+++ b/src/WorldFacade.js
@@ -460,7 +460,7 @@ class WorldFacade {
 	}
 
 	// TODO: pass data with roll - such as roll name. Passed back at the end in the results
-	roll(notation, {theme = this.config.theme, themeColor = this.config.themeColor, newStartPoint = true} = {}) {
+        roll(notation, {theme = this.config.theme, themeColor = this.config.themeColor, newStartPoint = true, desiredValue} = {}) {
 		// note: to add to a roll on screen use .add method
 		// reset the offscreen worker and physics worker with each new roll
 		this.clear()
@@ -474,14 +474,21 @@ class WorldFacade {
 			newStartPoint
 		})
 
-		const parsedNotation = this.createNotationArray(notation, this.themesLoadedData[theme].diceAvailable)
+                const parsedNotation = this.createNotationArray(notation, this.themesLoadedData[theme].diceAvailable)
+                if(desiredValue !== undefined){
+                        parsedNotation.forEach(n => {
+                                if(n.value === undefined){
+                                        n.value = desiredValue
+                                }
+                        })
+                }
 		this.#makeRoll(parsedNotation, collectionId)
 
 		// returns a Promise that is resolved in onRollComplete
 		return this.rollCollectionData[collectionId].promise
 	}
 
-  add(notation, {theme = this.config.theme, themeColor = this.config.themeColor, newStartPoint = true} = {}) {
+  add(notation, {theme = this.config.theme, themeColor = this.config.themeColor, newStartPoint = true, desiredValue} = {}) {
 
 		const collectionId = this.#collectionIndex++
 
@@ -493,7 +500,14 @@ class WorldFacade {
 			newStartPoint
 		})
 		
-		const parsedNotation = this.createNotationArray(notation, this.themesLoadedData[theme].diceAvailable)
+                const parsedNotation = this.createNotationArray(notation, this.themesLoadedData[theme].diceAvailable)
+                if(desiredValue !== undefined){
+                        parsedNotation.forEach(n => {
+                                if(n.value === undefined){
+                                        n.value = desiredValue
+                                }
+                        })
+                }
 		this.#makeRoll(parsedNotation, collectionId)
 
 		// returns a Promise that is resolved in onRollComplete
@@ -610,18 +624,19 @@ class WorldFacade {
           notation.sides =  parseInt(notation.sides.replace('d', ''))
         }
 
-				const roll = {
-					sides: notation.sides,
-					data: notation.data,
-					dieType,
-					groupId: index,
-					collectionId: collection.id,
-					rollId,
-					id,
-					theme,
-					themeColor,
-					meshName
-				}
+                                const roll = {
+                                        sides: notation.sides,
+                                        data: notation.data,
+                                        dieType,
+                                        groupId: index,
+                                        collectionId: collection.id,
+                                        rollId,
+                                        id,
+                                        theme,
+                                        themeColor,
+                                        meshName,
+                                        forceResult: notation.value
+                                }
 
 				rolls[rollId] = roll
 				this.rollDiceData[rollId] = roll
@@ -630,11 +645,11 @@ class WorldFacade {
 				// TODO: eliminate the 'd' for more flexible naming such as 'fate' - ensure numbers are strings
 				if (roll.sides === 'fate' && (!diceAvailable.includes(dieType) && !diceExtra.includes(dieType)) || roll.sides === 'fate' && !this.#webgl_support){
 					console.warn(`fate die unavailable in '${theme}' theme. Using fallback.`)
-					const min = -1
-					const max = 1
-					roll.value = Random.range(min,max)
-					this.#DiceWorld.addNonDie(roll)
-				} else if(this.config.suspendSimulation || (!diceAvailable.includes(dieType) && !diceExtra.includes(dieType)) || !this.#webgl_support){
+                                        const min = -1
+                                        const max = 1
+                                        roll.value = notation.value ?? Random.range(min,max)
+                                        this.#DiceWorld.addNonDie(roll)
+                                } else if(this.config.suspendSimulation || (!diceAvailable.includes(dieType) && !diceExtra.includes(dieType)) || !this.#webgl_support){
 					// check if the requested roll is available in the current theme, if not then use crypto fallback
 					const warning = 
 					!this.#webgl_support 
@@ -643,10 +658,10 @@ class WorldFacade {
 							? "3D simulation suspended. Using fallback." 
 							: `${roll.sides} die unavailable in '${theme}' theme. Using fallback.`
 					console.warn(warning)
-					const max = Number.isInteger(roll.sides) ? roll.sides : parseInt(roll.sides.replace(/\D/g,''))
-					roll.value = Random.range(1, max)
-					this.#DiceWorld.addNonDie(roll)
-				} else {
+                                        const max = Number.isInteger(roll.sides) ? roll.sides : parseInt(roll.sides.replace(/\D/g,''))
+                                        roll.value = notation.value ?? Random.range(1, max)
+                                        this.#DiceWorld.addNonDie(roll)
+                                } else {
 					let extendedTheme
 					if(diceExtra.includes(dieType)) {
 						const extendedThemeName = diceExtended[dieType]

--- a/src/components/Dice.js
+++ b/src/components/Dice.js
@@ -26,6 +26,7 @@ class Dice {
   asleep = false
   constructor(options, scene) {
     this.config = {...defaultOptions, ...options}
+    this.forceResult = options.forceResult
     this.id = this.config.id !== undefined ? this.config.id : Date.now()
     this.sides = this.config.sides
 		this.dieType = this.config.dieType

--- a/src/components/world.none.js
+++ b/src/components/world.none.js
@@ -41,12 +41,13 @@ class WorldNone {
 	addNonDie(die){
 		console.log('die', die)
 		clearTimeout(this.#rollCompleteTimer)
-		const {id, value, ...rest} = die
-		const newDie = {
-			id,
-			value,
-			config: rest
-		}
+                const {id, value, forceResult, ...rest} = die
+                const newDie = {
+                        id,
+                        value,
+                        forceResult,
+                        config: rest
+                }
 		this.#dieCache[id] = newDie
 		
 		this.#dieRollTimer.push(setTimeout(() => {
@@ -110,7 +111,10 @@ class WorldNone {
 		die.asleep = true
 	
 		// get the roll result for this die
-		await Dice.getRollResult(die)
+                await Dice.getRollResult(die)
+                if(die.forceResult !== undefined){
+                        die.value = die.forceResult
+                }
 	
 		if(die.d10Instance || die.dieParent) {
 			// if one of the pair is asleep and the other isn't then it falls through without getting the roll result
@@ -118,11 +122,14 @@ class WorldNone {
 			if(die?.d10Instance?.asleep || die?.dieParent?.asleep) {
 				const d100 = die.config.sides === 100 ? die : die.dieParent
 				const d10 = die.config.sides === 10 ? die : die.d10Instance
-				if (d10.value === 0 && d100.value === 0) {
-					d100.value = 100; // 00 + 0 is 100 on a d100
-				} else {
-					d100.value = d100.value + d10.value
-				}
+                                if (d10.value === 0 && d100.value === 0) {
+                                        d100.value = 100
+                                } else {
+                                        d100.value = d100.value + d10.value
+                                }
+                                if(d100.forceResult !== undefined){
+                                        d100.value = d100.forceResult
+                                }
 	
 				this.onRollResult({
 					rollId: d100.config.rollId,

--- a/src/components/world.onscreen.js
+++ b/src/components/world.onscreen.js
@@ -224,12 +224,13 @@ class WorldOnscreen {
 		if(this.#engine.activeRenderLoops.length === 0) {
 			this.render(false)
 		}
-		const {id, value, ...rest} = die
-		const newDie = {
-			id,
-			value,
-			config: rest
-		}
+                const {id, value, forceResult, ...rest} = die
+                const newDie = {
+                        id,
+                        value,
+                        forceResult,
+                        config: rest
+                }
 		this.#dieCache[id] = newDie
 		
 		// double timeout to ensure any real dice have a chance to queue up and rollResults isn't triggered right away
@@ -384,7 +385,10 @@ class WorldOnscreen {
 		die.asleep = true
 	
 		// get the roll result for this die
-		await Dice.getRollResult(die, this.#scene)
+                await Dice.getRollResult(die, this.#scene)
+                if(die.forceResult !== undefined){
+                        die.value = die.forceResult
+                }
 	
 		if(die.d10Instance || die.dieParent) {
 			// if one of the pair is asleep and the other isn't then it falls through without getting the roll result
@@ -399,7 +403,10 @@ class WorldOnscreen {
 				// save the original value
 				d100.rawValue = d100.value
 
-				d100.value = d100.value + d10.value
+                                d100.value = d100.value + d10.value
+                                if(d100.forceResult !== undefined){
+                                        d100.value = d100.forceResult
+                                }
 	
 				this.onRollResult({
 					rollId: d100.config.rollId,


### PR DESCRIPTION
## Summary
- allow passing a desiredValue when rolling or adding dice
- carry forcedResult into dice instances and results
- support forced results in onscreen and fallback worlds
- allow fallback dice to keep predetermined values

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863492877b48333b173f73dfc91ae24

## Summary by Sourcery

Enable specifying and enforcing custom dice roll results across all rendering modes

New Features:
- Allow passing a desiredValue when invoking roll() or add() to preset dice outcomes
- Attach a forceResult field to each die in roll creation and propagate it through Dice instances
- Apply forced results in both onscreen and non-graphical worlds, overriding random values
- Support predetermined values for fallback dice simulations